### PR TITLE
build: Build docker image on push

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - '**.md'
 
 env:
   AWS_REGION: eu-north-1


### PR DESCRIPTION
This will enable Github actions to build on push. Fixes #14